### PR TITLE
introduce append mode for dump command.

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"log"
+	"path/filepath"
+	"strings"
 
 	"github.com/simonwhitaker/gibo/utils"
 	"github.com/spf13/cobra"
@@ -17,10 +19,43 @@ var dumpCmd = &cobra.Command{
 	Args:      cobra.MinimumNArgs(1),
 	ValidArgs: utils.ListBoilerplatesNoError(),
 	Run: func(cmd *cobra.Command, args []string) {
-		for _, boilerplate := range args {
-			if err := utils.PrintBoilerplate(boilerplate); err != nil {
-				log.Fatalf("On dumping %v: %v", boilerplate, err)
+		if isAppendMode(args) {
+			results, err := findBoilerplatesInGitignoreFile(filepath.Join(".", gitignoreFileName))
+			if err != nil {
+				log.Fatal(err.Error())
 			}
+			dumpBoilerplate(concatNames(results, args))
+		} else {
+			dumpBoilerplate(args)
 		}
 	},
+}
+
+func concatNames(results []string, args []string) []string {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "+") {
+			results = append(results, arg[1:])
+		} else {
+			results = append(results, arg)
+		}
+	}
+	return results
+}
+
+func isAppendMode(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "+") {
+			return true
+		}
+	}
+	return false
+}
+
+func dumpBoilerplate(args []string) error {
+	for _, boilerplate := range args {
+		if err := utils.PrintBoilerplate(boilerplate); err != nil {
+			log.Fatalf("On dumping %v: %v", boilerplate, err)
+		}
+	}
+	return nil
 }

--- a/cmd/list-ignore.go
+++ b/cmd/list-ignore.go
@@ -22,7 +22,7 @@ func init() {
 
 var listIgnoreCmd = &cobra.Command{
 	Use:   "list-ignore",
-	Short: "List boilerplates in the .gitignore file.",
+	Short: "List boilerplates in the .gitignore file",
 	Run: func(cmd *cobra.Command, args []string) {
 		list, err := findRegisteredBoilerplates(args)
 		if err != nil {


### PR DESCRIPTION
If any of the arguments of the dump command starts with `+,` the boilerplate is dumped in append mode.

In append mode, at first, `gibo` extracts the list of boilerplates in the current `.gitignore` file.
Then, we add the arguments of `dump` command to the list.
Finally, `gibo` dumps boilerplates of the resultant name list.
